### PR TITLE
Do not show warning when running firebase-admin in a Cloudflare Worker

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -19,7 +19,10 @@ import * as firebase from './default-namespace';
 
 // Only Node.js has a process variable that is of [[Class]] process
 const processGlobal = typeof process !== 'undefined' ? process : 0;
-if (Object.prototype.toString.call(processGlobal) !== '[object process]') {
+const isNodejs = Object.prototype.toString.call(processGlobal) === '[object process]';
+const isCloudflareWorker = typeof navigator !== 'undefined' && navigator.userAgent === 'Cloudflare-Workers';
+
+if (!isNodejs && !isCloudflareWorker) {
   const message = `
 ======== WARNING! ========
 


### PR DESCRIPTION
The current error states:

```
firebase-admin appears to have been installed in an unsupported environment.
This package should only be used in server-side or backend Node.js environments,
and should not be used in web browsers or other client-side environments.
```

[Cloudflare Workers](https://developers.cloudflare.com/workers) are a server-side environment.

Cloudflare sets the value of `navigator.userAgent` to `'Cloudflare-Workers'` in order to allow NPM packages to use this property to detect if they are running in the Workers runtime, and avoid having to sniff using `process` or other globals.

https://developers.cloudflare.com/workers/runtime-apis/web-standards/#navigatoruseragent